### PR TITLE
Parse and print include directives

### DIFF
--- a/parse/node.go
+++ b/parse/node.go
@@ -58,16 +58,18 @@ const (
 	NodeComment
 	NodeSpace
 	NodeAmount
+	NodeDirective
 )
 
 var nodeLabel = map[NodeType]string{
-	NodeJournal: "NodeJournal",
-	NodeList:    "NodeList",
-	NodeXact:    "NodeXact",
-	NodePosting: "NodePosting",
-	NodeComment: "NodeComment",
-	NodeSpace:   "NodeSpace",
-	NodeAmount:  "NodeAmount",
+	NodeJournal:   "NodeJournal",
+	NodeList:      "NodeList",
+	NodeXact:      "NodeXact",
+	NodePosting:   "NodePosting",
+	NodeComment:   "NodeComment",
+	NodeSpace:     "NodeSpace",
+	NodeAmount:    "NodeAmount",
+	NodeDirective: "NodeDirective",
 }
 
 /** ListNode **/
@@ -289,3 +291,28 @@ func (n *AmountNode) space(t *Tree) {
 		n.next(t)
 	}
 }
+
+type DirectiveNode struct {
+	NodeType
+	Pos
+	tr *Tree
+
+	Raw       string
+	Directive string
+	Args      string
+}
+
+func (t *Tree) newDirective(p Pos, directive string) *DirectiveNode {
+	d := &DirectiveNode{NodeType: NodeDirective, Pos: p, tr: t, Directive: directive}
+	t.Root.add(d)
+	return d
+}
+
+func (n *DirectiveNode) String() string {
+	str := n.Directive
+	if n.Args != "" {
+		str += " " + n.Args
+	}
+	return str
+}
+func (n *DirectiveNode) tree() *Tree { return n.tr }

--- a/print/print.go
+++ b/print/print.go
@@ -41,24 +41,19 @@ func (p *Printer) Print(buf *bytes.Buffer) error {
 	for _, nodeIface := range tree.Root.Nodes {
 		switch node := nodeIface.(type) {
 		case *parse.XactNode:
-
-			if err = plainXact.Execute(buf, node); err != nil {
-				return err
-			}
+			err = plainXact.Execute(buf, node)
 		case *parse.CommentNode:
-			_, err := buf.WriteString(node.Comment + "\n")
-			if err != nil {
-				return err
-			}
-
+			_, err = buf.WriteString(node.Comment + "\n")
 		case *parse.SpaceNode:
-			_, err := buf.WriteString(node.Space)
-			if err != nil {
-				return err
-			}
-
+			_, err = buf.WriteString(node.Space)
+		case *parse.DirectiveNode:
+			_, err = buf.WriteString(node.Raw)
 		default:
 			return fmt.Errorf("unprintable node type %T", nodeIface)
+		}
+
+		if err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
Hi,

This implements parsing of "include file" directives into a new DirectiveNode and adds printing support for them. I chose a more general node type instead of "IncludeNode" because this way we can easily extend it for similar one-line directives.